### PR TITLE
Flash Messages are now lists of strings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,9 +41,10 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",
-        "phpunit/phpunit": "^10.2.2",
+        "laminas/laminas-diactoros": "^3.3",
+        "phpunit/phpunit": "^10.5.7",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.13.1"
+        "vimeo/psalm": "^5.20.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "mezzio/mezzio-session": "^1.0",
+        "mezzio/mezzio-session": "^1.7",
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae0f596a8d53f77a3c74ded00877f564",
+    "content-hash": "4162f62932b13c90e2562654a5e2dad9",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -1153,6 +1153,91 @@
             "time": "2023-01-05T15:53:40+00:00"
         },
         {
+            "name": "laminas/laminas-diactoros",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-diactoros.git",
+                "reference": "4db52734837c60259c9b2d7caf08eef8f7f9b9ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/4db52734837c60259c9b2d7caf08eef8f7f9b9ac",
+                "reference": "4db52734837c60259c9b2d7caf08eef8f7f9b9ac",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "psr/http-factory": "^1.0.2",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "^1.1 || ^2.0",
+                "psr/http-message-implementation": "^1.1 || ^2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "ext-dom": "*",
+                "ext-gd": "*",
+                "ext-libxml": "*",
+                "http-interop/http-factory-tests": "^0.9.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "php-http/psr7-integration-tests": "^1.3",
+                "phpunit/phpunit": "^9.5.28",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.15.0"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Laminas\\Diactoros\\ConfigProvider",
+                    "module": "Laminas\\Diactoros"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions/create_uploaded_file.php",
+                    "src/functions/marshal_headers_from_sapi.php",
+                    "src/functions/marshal_method_from_sapi.php",
+                    "src/functions/marshal_protocol_version_from_sapi.php",
+                    "src/functions/normalize_server.php",
+                    "src/functions/normalize_uploaded_files.php",
+                    "src/functions/parse_cookie_header.php"
+                ],
+                "psr-4": {
+                    "Laminas\\Diactoros\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "PSR HTTP Message implementations",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "http",
+                "laminas",
+                "psr",
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-diactoros/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-diactoros/issues",
+                "rss": "https://github.com/laminas/laminas-diactoros/releases.atom",
+                "source": "https://github.com/laminas/laminas-diactoros"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2023-10-26T11:01:07+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.11.1",
             "source": {
@@ -2119,6 +2204,61 @@
                 "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.18.4"
             },
             "time": "2022-12-03T07:47:07+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:10:41+00:00"
         },
         {
             "name": "psr/log",
@@ -4063,16 +4203,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.19.0",
+            "version": "5.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "06b71be009a6bd6d81b9811855d6629b9fe90e1b"
+                "reference": "3f284e96c9d9be6fe6b15c79416e1d1903dcfef4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/06b71be009a6bd6d81b9811855d6629b9fe90e1b",
-                "reference": "06b71be009a6bd6d81b9811855d6629b9fe90e1b",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/3f284e96c9d9be6fe6b15c79416e1d1903dcfef4",
+                "reference": "3f284e96c9d9be6fe6b15c79416e1d1903dcfef4",
                 "shasum": ""
             },
             "require": {
@@ -4169,7 +4309,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2024-01-09T21:02:43+00:00"
+            "time": "2024-01-18T12:15:06+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4162f62932b13c90e2562654a5e2dad9",
+    "content-hash": "791657345a69412dfe9e466082cbd8dd",
     "packages": [
         {
             "name": "dflydev/fig-cookies",

--- a/src/FlashMessageMiddleware.php
+++ b/src/FlashMessageMiddleware.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Mezzio\Flash;
 
+use Mezzio\Session\RetrieveSession;
 use Mezzio\Session\SessionInterface;
-use Mezzio\Session\SessionMiddleware;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -13,7 +13,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 use function is_callable;
 
-class FlashMessageMiddleware implements MiddlewareInterface
+final class FlashMessageMiddleware implements MiddlewareInterface
 {
     public const FLASH_ATTRIBUTE = 'flash';
 
@@ -22,8 +22,8 @@ class FlashMessageMiddleware implements MiddlewareInterface
 
     public function __construct(
         string $flashMessagesClass = FlashMessages::class,
-        private string $sessionKey = FlashMessagesInterface::FLASH_NEXT,
-        private string $attributeKey = self::FLASH_ATTRIBUTE
+        private readonly string $sessionKey = FlashMessagesInterface::FLASH_NEXT,
+        private readonly string $attributeKey = self::FLASH_ATTRIBUTE
     ) {
         $factory = [$flashMessagesClass, 'createFromSession'];
         if (! is_callable($factory)) {
@@ -35,7 +35,7 @@ class FlashMessageMiddleware implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE, false);
+        $session = RetrieveSession::fromRequestOrNull($request);
         if (! $session instanceof SessionInterface) {
             throw Exception\MissingSessionException::forMiddleware($this);
         }

--- a/src/FlashMessagesInterface.php
+++ b/src/FlashMessagesInterface.php
@@ -18,6 +18,8 @@ interface FlashMessagesInterface
      *
      * Flash messages will be retrieved from and persisted to the session via
      * the `$sessionKey`.
+     *
+     * @param non-empty-string $sessionKey
      */
     public static function createFromSession(
         SessionInterface $session,
@@ -31,9 +33,11 @@ interface FlashMessagesInterface
      * next time the session is accessed; you may pass an additional $hops
      * integer to allow access for more than one hop.
      *
-     * @param mixed $value
+     * @param non-empty-string $key
+     * @param non-empty-string $value
+     * @param positive-int $hops
      */
-    public function flash(string $key, $value, int $hops = 1): void;
+    public function flash(string $key, string $value, int $hops = 1): void;
 
     /**
      * Set a flash value with the given key, but allow access during this request.
@@ -42,9 +46,11 @@ interface FlashMessagesInterface
      * using this method, you may make the value available during the current
      * request as well.
      *
-     * @param mixed $value
+     * @param non-empty-string $key
+     * @param non-empty-string $value
+     * @param non-negative-int $hops
      */
-    public function flashNow(string $key, $value, int $hops = 1): void;
+    public function flashNow(string $key, string $value, int $hops = 1): void;
 
     /**
      * Retrieve a flash value.
@@ -54,10 +60,11 @@ interface FlashMessagesInterface
      *
      * WILL NOT return a value if set in the current request via `flash()`.
      *
-     * @param mixed $default Default value to return if no flash value exists.
-     * @return mixed
+     * @param non-empty-string $key
+     * @param list<non-empty-string> $default Default value to return if no flash value exists.
+     * @return list<non-empty-string>
      */
-    public function getFlash(string $key, $default = null);
+    public function getFlash(string $key, array $default = []): array;
 
     /**
      * Retrieve all flash values.
@@ -67,7 +74,7 @@ interface FlashMessagesInterface
      *
      * WILL NOT return values set in the current request via `flash()`.
      *
-     * @return array
+     * @return array<string, list<non-empty-string>>
      */
     public function getFlashes(): array;
 

--- a/test/FlashMessagesTest.php
+++ b/test/FlashMessagesTest.php
@@ -7,33 +7,21 @@ namespace MezzioTest\Flash;
 use Mezzio\Flash\Exception\InvalidHopsValueException;
 use Mezzio\Flash\FlashMessages;
 use Mezzio\Flash\FlashMessagesInterface;
+use Mezzio\Session\Session;
 use Mezzio\Session\SessionInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-
-use function in_array;
 
 class FlashMessagesTest extends TestCase
 {
-    private SessionInterface&MockObject $session;
+    private SessionInterface $session;
 
     public function setUp(): void
     {
-        $this->session = $this->createMock(SessionInterface::class);
+        $this->session = new Session([]);
     }
 
     public function testCreationAggregatesNothingIfNoMessagesExistUnderSpecifiedSessionKey(): void
     {
-        $this->session
-            ->expects(self::once())
-            ->method('has')
-            ->with(FlashMessagesInterface::FLASH_NEXT)
-            ->willReturn(false);
-        $this->session
-            ->expects(self::never())
-            ->method('get')
-            ->with(FlashMessagesInterface::FLASH_NEXT);
-
         $flash = FlashMessages::createFromSession($this->session);
         self::assertInstanceOf(FlashMessages::class, $flash);
         self::assertSame([], $flash->getFlashes());
@@ -42,351 +30,192 @@ class FlashMessagesTest extends TestCase
     public function testCreationAggregatesItemsMarkedNextAndRemovesThemFromSession(): void
     {
         $messages = [
-            'test'   => [
-                'hops'  => 1,
-                'value' => 'value1',
+            'info'    => [
+                [
+                    'hops'  => 1,
+                    'value' => 'value1',
+                ],
             ],
-            'test-2' => [
-                'hops'  => 1,
-                'value' => 'value2',
+            'warning' => [
+                [
+                    'hops'  => 1,
+                    'value' => 'value2',
+                ],
             ],
         ];
 
-        $this->session
-            ->expects(self::once())
-            ->method('has')
-            ->with(FlashMessagesInterface::FLASH_NEXT)
-            ->willReturn(true);
-        $this->session
-            ->expects(self::once())
-            ->method('get')
-            ->with(FlashMessagesInterface::FLASH_NEXT)
-            ->willReturn($messages);
-        $this->session
-            ->expects(self::once())
-            ->method('unset')
-            ->with(FlashMessagesInterface::FLASH_NEXT);
+        $this->session->set(FlashMessagesInterface::FLASH_NEXT, $messages);
+        $flash = FlashMessages::createFromSession($this->session);
+
+        self::assertSame(['value1'], $flash->getFlash('info'));
+        self::assertSame(['value2'], $flash->getFlash('warning'));
+        self::assertSame(['info' => ['value1'], 'warning' => ['value2']], $flash->getFlashes());
 
         $flash = FlashMessages::createFromSession($this->session);
-        self::assertInstanceOf(FlashMessages::class, $flash);
-
-        self::assertSame('value1', $flash->getFlash('test'));
-        self::assertSame('value2', $flash->getFlash('test-2'));
-        self::assertSame(['test' => 'value1', 'test-2' => 'value2'], $flash->getFlashes());
+        self::assertSame([], $flash->getFlash('info'));
+        self::assertSame([], $flash->getFlash('warning'));
+        self::assertSame([], $flash->getFlashes());
     }
 
-    public function testCreationAggregatesPersistsItemsWithMultipleHopsInSessionWithDecrementedHops(): void
+    public function testCreationAggregatesItemsWithMultipleHopsInSessionWithDecrementedHops(): void
     {
-        $messages                           = [
+        $messages = [
             'test'   => [
-                'hops'  => 3,
-                'value' => 'value1',
+                [
+                    'hops'  => 3,
+                    'value' => 'value1',
+                ],
             ],
             'test-2' => [
-                'hops'  => 2,
-                'value' => 'value2',
+                [
+                    'hops'  => 2,
+                    'value' => 'value2',
+                ],
             ],
         ];
-        $messagesExpected                   = $messages;
-        $messagesExpected['test']['hops']   = 2;
-        $messagesExpected['test-2']['hops'] = 1;
-
-        $this->session
-            ->expects(self::once())
-            ->method('has')
-            ->with(FlashMessagesInterface::FLASH_NEXT)
-            ->willReturn(true);
-        $this->session
-            ->expects(self::once())
-            ->method('get')
-            ->with(FlashMessagesInterface::FLASH_NEXT)
-            ->willReturn($messages);
-        $this->session
-            ->expects(self::once())
-            ->method('set')
-            ->with(
-                FlashMessagesInterface::FLASH_NEXT,
-                $messagesExpected
-            );
+        $this->session->set(FlashMessagesInterface::FLASH_NEXT, $messages);
+        $messagesExpected                      = $messages;
+        $messagesExpected['test'][0]['hops']   = 2;
+        $messagesExpected['test-2'][0]['hops'] = 1;
 
         $flash = FlashMessages::createFromSession($this->session);
-        self::assertInstanceOf(FlashMessages::class, $flash);
+        self::assertSame(['value1'], $flash->getFlash('test'));
+        self::assertSame(['value2'], $flash->getFlash('test-2'));
+        self::assertSame(['test' => ['value1'], 'test-2' => ['value2']], $flash->getFlashes());
 
-        self::assertSame('value1', $flash->getFlash('test'));
-        self::assertSame('value2', $flash->getFlash('test-2'));
-        self::assertSame(['test' => 'value1', 'test-2' => 'value2'], $flash->getFlashes());
+        $sessionValues = $this->session->get(FlashMessagesInterface::FLASH_NEXT);
+        self::assertSame($messagesExpected, $sessionValues);
     }
 
     public function testFlashingAValueMakesItAvailableInNextSessionButNotFlashMessages(): void
     {
-        $this->session
-            ->expects(self::once())
-            ->method('has')
-            ->with(FlashMessagesInterface::FLASH_NEXT)
-            ->willReturn(false);
-        $this->session
-            ->expects(self::once())
-            ->method('get')
-            ->with(FlashMessagesInterface::FLASH_NEXT, [])
-            ->willReturn([]);
-        $this->session
-            ->expects(self::once())
-            ->method('set')
-            ->with(
-                FlashMessagesInterface::FLASH_NEXT,
-                [
-                    'test' => [
-                        'value' => 'value',
-                        'hops'  => 1,
-                    ],
-                ]
-            );
-
         $flash = FlashMessages::createFromSession($this->session);
         $flash->flash('test', 'value');
 
-        self::assertNull($flash->getFlash('test'));
+        self::assertSame([], $flash->getFlash('test'));
         self::assertSame([], $flash->getFlashes());
     }
 
     public function testFlashNowMakesValueAvailableBothInNextSessionAndCurrentFlashMessages(): void
     {
-        $this->session
-            ->expects(self::once())
-            ->method('has')
-            ->with(FlashMessagesInterface::FLASH_NEXT)
-            ->willReturn(false);
-        $this->session
-            ->expects(self::once())
-            ->method('get')
-            ->with(FlashMessagesInterface::FLASH_NEXT, [])
-            ->willReturn([]);
-        $this->session
-            ->expects(self::once())
-            ->method('set')
-            ->with(
-                FlashMessagesInterface::FLASH_NEXT,
-                [
-                    'test' => [
-                        'value' => 'value',
-                        'hops'  => 1,
-                    ],
-                ]
-            );
-
         $flash = FlashMessages::createFromSession($this->session);
         $flash->flashNow('test', 'value');
 
-        self::assertSame('value', $flash->getFlash('test'));
-        self::assertSame(['test' => 'value'], $flash->getFlashes());
+        self::assertSame(['value'], $flash->getFlash('test'));
+        self::assertSame(['test' => ['value']], $flash->getFlashes());
+
+        $flash = FlashMessages::createFromSession($this->session);
+
+        self::assertSame(['value'], $flash->getFlash('test'));
+        self::assertSame(['test' => ['value']], $flash->getFlashes());
+
+        $flash = FlashMessages::createFromSession($this->session);
+
+        self::assertSame([], $flash->getFlash('test'));
+        self::assertSame([], $flash->getFlashes());
     }
 
     public function testProlongFlashAddsCurrentMessagesToNextSession(): void
     {
         $messages = [
             'test'   => [
-                'hops'  => 1,
-                'value' => 'value1',
+                [
+                    'hops'  => 1,
+                    'value' => 'value1',
+                ],
             ],
             'test-2' => [
-                'hops'  => 1,
-                'value' => 'value2',
-            ],
-        ];
-
-        $invocationCounter = new class {
-            public int $count = 0;
-        };
-
-        $this->session
-            ->expects(self::once())
-            ->method('has')
-            ->with(FlashMessagesInterface::FLASH_NEXT)
-            ->willReturn(true);
-        $this->session
-            ->expects(self::exactly(4))
-            ->method('get')
-            ->with(self::callback(static function (string $key): bool {
-                self::assertSame(FlashMessagesInterface::FLASH_NEXT, $key);
-
-                return true;
-            }))
-            ->willReturnCallback(static function () use ($messages, $invocationCounter) {
-                $invocationCounter->count += 1;
-
-                if ($invocationCounter->count === 1) {
-                    return $messages;
-                }
-
-                return [];
-            });
-        $this->session
-            ->expects(self::once())
-            ->method('unset')
-            ->with(FlashMessagesInterface::FLASH_NEXT);
-
-        $expectInSet = [
-            [
-                'test' => [
-                    'value' => 'value1',
+                [
                     'hops'  => 1,
-                ],
-            ],
-            [
-                'test-2' => [
                     'value' => 'value2',
-                    'hops'  => 1,
                 ],
             ],
         ];
-
-        $this->session
-            ->expects(self::exactly(2))
-            ->method('set')
-            ->with(
-                self::identicalTo(FlashMessagesInterface::FLASH_NEXT),
-                self::callback(fn ($arg): bool => in_array($arg, $expectInSet, true)),
-            );
+        $this->session->set(FlashMessagesInterface::FLASH_NEXT, $messages);
 
         $flash = FlashMessages::createFromSession($this->session);
-        self::assertInstanceOf(FlashMessages::class, $flash);
 
-        self::assertSame('value1', $flash->getFlash('test'));
-        self::assertSame('value2', $flash->getFlash('test-2'));
-        self::assertSame(['test' => 'value1', 'test-2' => 'value2'], $flash->getFlashes());
+        self::assertSame(['test' => ['value1'], 'test-2' => ['value2']], $flash->getFlashes());
 
         $flash->prolongFlash();
+
+        $flash = FlashMessages::createFromSession($this->session);
+
+        self::assertSame(['test' => ['value1'], 'test-2' => ['value2']], $flash->getFlashes());
+
+        $flash = FlashMessages::createFromSession($this->session);
+
+        self::assertSame([], $flash->getFlashes());
     }
 
     public function testProlongFlashDoesNotReFlashMessagesThatAlreadyHaveMoreHops(): void
     {
-        $messages                           = [
+        $messages = [
             'test'   => [
-                'hops'  => 3,
-                'value' => 'value1',
+                [
+                    'hops'  => 3,
+                    'value' => 'value1',
+                ],
             ],
             'test-2' => [
-                'hops'  => 2,
-                'value' => 'value2',
+                [
+                    'hops'  => 2,
+                    'value' => 'value2',
+                ],
+            ],
+            'test-3' => [
+                [
+                    'hops'  => 1,
+                    'value' => 'value3',
+                ],
             ],
         ];
-        $messagesExpected                   = $messages;
-        $messagesExpected['test']['hops']   = 2;
-        $messagesExpected['test-2']['hops'] = 1;
-
-        $invocationCounter = new class {
-            public int $count = 0;
-        };
-
-        $this->session
-            ->expects(self::once())
-            ->method('has')
-            ->with(FlashMessagesInterface::FLASH_NEXT)
-            ->willReturn(true);
-        $this->session
-            ->expects(self::atMost(2))
-            ->method('get')
-            ->with(
-                self::identicalTo(FlashMessagesInterface::FLASH_NEXT),
-                self::callback(fn ($arg): bool => in_array($arg, [null, []], true)),
-            )
-            ->willReturnCallback(static function () use ($messagesExpected, $messages, $invocationCounter) {
-                $invocationCounter->count += 1;
-
-                if ($invocationCounter->count === 1) {
-                    return $messages;
-                }
-
-                return $messagesExpected;
-            });
-        $this->session
-            ->expects(self::once())
-            ->method('set')
-            ->with(
-                FlashMessagesInterface::FLASH_NEXT,
-                $messagesExpected
-            );
+        $this->session->set(FlashMessagesInterface::FLASH_NEXT, $messages);
 
         $flash = FlashMessages::createFromSession($this->session);
-        self::assertInstanceOf(FlashMessages::class, $flash);
-
-        self::assertSame('value1', $flash->getFlash('test'));
-        self::assertSame('value2', $flash->getFlash('test-2'));
-        self::assertSame(['test' => 'value1', 'test-2' => 'value2'], $flash->getFlashes());
+        self::assertSame(['test' => ['value1'], 'test-2' => ['value2'], 'test-3' => ['value3']], $flash->getFlashes());
 
         $flash->prolongFlash();
+
+        $flash = FlashMessages::createFromSession($this->session);
+        self::assertSame(['test' => ['value1'], 'test-2' => ['value2'], 'test-3' => ['value3']], $flash->getFlashes());
+
+        $flash = FlashMessages::createFromSession($this->session);
+        self::assertSame(['test' => ['value1']], $flash->getFlashes());
+
+        $flash = FlashMessages::createFromSession($this->session);
+        self::assertSame([], $flash->getFlashes());
     }
 
     public function testClearFlashShouldRemoveAnyUnexpiredMessages(): void
     {
-        $messages                           = [
+        $messages = [
             'test'   => [
-                'hops'  => 3,
-                'value' => 'value1',
+                ['hops' => 3, 'value' => 'value1'],
             ],
             'test-2' => [
-                'hops'  => 2,
-                'value' => 'value2',
+                ['hops' => 2, 'value' => 'value2'],
+            ],
+            'test-3' => [
+                ['hops' => 1, 'value' => 'value3'],
             ],
         ];
-        $messagesExpected                   = $messages;
-        $messagesExpected['test']['hops']   = 2;
-        $messagesExpected['test-2']['hops'] = 1;
-
-        $this->session
-            ->expects(self::once())
-            ->method('has')
-            ->with(FlashMessagesInterface::FLASH_NEXT)
-            ->willReturn(true);
-        $this->session
-            ->expects(self::once())
-            ->method('get')
-            ->with(FlashMessagesInterface::FLASH_NEXT)
-            ->willReturn($messages);
-        $this->session
-            ->expects(self::once())
-            ->method('set')
-            ->with(
-                FlashMessagesInterface::FLASH_NEXT,
-                $messagesExpected
-            );
-        $this->session
-            ->expects(self::once())
-            ->method('unset')
-            ->with(FlashMessagesInterface::FLASH_NEXT);
+        $this->session->set(FlashMessagesInterface::FLASH_NEXT, $messages);
 
         $flash = FlashMessages::createFromSession($this->session);
-        self::assertInstanceOf(FlashMessages::class, $flash);
+        self::assertSame(['test' => ['value1'], 'test-2' => ['value2'], 'test-3' => ['value3']], $flash->getFlashes());
+        $flash->clearFlash();
 
-        self::assertSame('value1', $flash->getFlash('test'));
-        self::assertSame('value2', $flash->getFlash('test-2'));
-        self::assertSame(['test' => 'value1', 'test-2' => 'value2'], $flash->getFlashes());
+        $flash = FlashMessages::createFromSession($this->session);
+        self::assertSame([], $flash->getFlashes());
         $flash->clearFlash();
     }
 
     public function testCreationAggregatesThrowsExceptionIfInvalidNumberOfHops(): void
     {
         $this->expectException(InvalidHopsValueException::class);
-
-        $this->session
-            ->expects(self::once())
-            ->method('has')
-            ->with(FlashMessagesInterface::FLASH_NEXT)
-            ->willReturn(false);
-        $this->session
-            ->expects(self::never())
-            ->method('get')
-            ->with(FlashMessagesInterface::FLASH_NEXT, [])
-            ->willReturn([]);
-        $this->session
-            ->expects(self::never())
-            ->method('set')
-            ->with(
-                self::anything(),
-                self::anything()
-            );
-
         $flash = FlashMessages::createFromSession($this->session);
+        /** @psalm-suppress InvalidArgument */
         $flash->flash('test', 'value', 0);
     }
 
@@ -395,16 +224,15 @@ class FlashMessagesTest extends TestCase
         $flash = FlashMessages::createFromSession($this->session);
         $flash->flashNow('test', 'value', 0);
 
-        self::assertSame('value', $flash->getFlash('test'));
+        self::assertSame(['value'], $flash->getFlash('test'));
     }
 
-    public function testFlashNowWithZeroHopsShouldNotSetValueToSession(): void
+    public function testFlashNowWithZeroHopsShouldNotBePresentInNextSession(): void
     {
-        $this->session
-            ->expects(self::never())
-            ->method('set');
-
         $flash = FlashMessages::createFromSession($this->session);
         $flash->flashNow('test', 'value', 0);
+        self::assertSame(['value'], $flash->getFlash('test'));
+        $flash = FlashMessages::createFromSession($this->session);
+        self::assertSame([], $flash->getFlash('test'));
     }
 }

--- a/test/TestAsset/FlashMessages.php
+++ b/test/TestAsset/FlashMessages.php
@@ -22,26 +22,20 @@ class FlashMessages implements FlashMessagesInterface
         return new self($session, $sessionKey);
     }
 
-    /**
-     * @param mixed $value
-     */
-    public function flash(string $key, $value, int $hops = 1): void
+    /** @inheritDoc */
+    public function flash(string $key, string $value, int $hops = 1): void
     {
     }
 
-    /**
-     * @param mixed $value
-     */
-    public function flashNow(string $key, $value, int $hops = 1): void
+    /** @inheritDoc */
+    public function flashNow(string $key, string $value, int $hops = 1): void
     {
     }
 
-    /**
-     * @param mixed|null $default
-     * @return void
-     */
-    public function getFlash(string $key, $default = null)
+    /** @inheritDoc */
+    public function getFlash(string $key, array $default = []): array
     {
+        return [];
     }
 
     public function getFlashes(): array

--- a/test/TestAsset/TestHandler.php
+++ b/test/TestAsset/TestHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Flash\TestAsset;
+
+use Laminas\Diactoros\Response\TextResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
+
+final class TestHandler implements RequestHandlerInterface
+{
+    public ?ServerRequestInterface $request = null;
+    public ResponseInterface $response;
+
+    public function __construct(ResponseInterface|null $response = null)
+    {
+        $this->response = $response ?? new TextResponse('Default Response');
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->request = $request;
+
+        return $this->response;
+    }
+
+    public function receivedRequest(): ServerRequestInterface
+    {
+        if (! $this->request) {
+            throw new RuntimeException('No request has been received');
+        }
+
+        return $this->request;
+    }
+
+    public function requestWasReceived(): bool
+    {
+        return $this->request !== null;
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | not-yet
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes
| RFC           | yes
| QA            | yes

This patch breaks BC so it'll need to go into 2.x if acceptable.

The main user-facing change is that flash messages are now `list<non-empty-string>` instead of `mixed`.

Previously:

```php
$flash->flash('info', 'whatever');
$flash->flash('info', 'other stuff');
// Next Hop
echo $flash->getFlash('info'); // "other stuff"
```

Now:

```php
$flash->flash('info', 'whatever');
$flash->flash('info', 'other stuff');
// Next Hop
var_dump($flash->getFlash('info')); // ["whatever", "other stuff"]
```

Tests have been simplified by replacing mocks with concrete instances. Considering that this library only works with Mezzio\Session, there's little point mocking Session and any BC breaks in Session will be discovered here during lock file maintenance.

Docs will need updating which I'll do in separate patch if this one is acceptable
